### PR TITLE
Make UnderDevFX modular

### DIFF
--- a/src/app/components/UnderDevFX.tsx
+++ b/src/app/components/UnderDevFX.tsx
@@ -4,21 +4,27 @@
 import { useEffect, useRef, useState } from "react";
 import { LetterFx } from "@/once-ui/components";
 
-export default function UnderDevFX() {
+type UnderDevFxProps = {
+  text: string;
+  /** Delay in milliseconds between effect triggers */
+  delay?: number;
+};
+
+export default function UnderDevFX({ text, delay = 10_000 }: UnderDevFxProps) {
   // 1) Use a ref to hold LetterFx’s internal eventHandler. Start as `null`.
   const handlerRef = useRef<(() => void) | null>(null);
 
-  // 2) A boolean that flips every 10 seconds
+  // 2) A boolean that flips according to the provided delay
   const [toggle, setToggle] = useState(false);
 
-  // 3) Flip `toggle` every 10s
+  // 3) Flip `toggle` based on `delay`
   useEffect(() => {
     const id = setInterval(() => {
       setToggle((prev) => !prev);
-    }, 10_000);
+    }, delay);
 
     return () => clearInterval(id);
-  }, []);
+  }, [delay]);
 
   // 4) Whenever `toggle` changes, call handlerRef.current (if non-null)
   useEffect(() => {
@@ -37,7 +43,7 @@ export default function UnderDevFX() {
       speed="slow"
       className="body-strong-xl"
     >
-      Currently Under Development!
+      {text}
     </LetterFx>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
                 </Text>
               </RevealFx>
               <RevealFx speed="fast" delay={0.2} translateY={4} center>
-                <UnderDevFX /> {/* TODO: Modify this component to make it modular (take in input: text, repeat time) */}
+                <UnderDevFX text="Currently Under Development!" delay={10_000} />
               </RevealFx>
               <Badge id="badge-3" title="Learn more" href="/temp"/>
           </Column>


### PR DESCRIPTION
## Summary
- accept text and delay props in the UnderDevFX component
- update `page.tsx` to pass text and delay value

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c88a968883328ae4bdbf4c2bf5e3